### PR TITLE
Want Psalm support for the di() function

### DIFF
--- a/src/z-helper.php
+++ b/src/z-helper.php
@@ -5,6 +5,12 @@ use DI\ApplicationContext;
 if (!function_exists('di')) {
     /**
      * Finds an entry of the container by its identifier and returns it.
+     *
+     * @template T
+     * @psalm-param class-string<T> $id
+     * @psalm-return T
+     * @psalm-suppress InvalidReturnStatement
+     *
      * @param null|mixed $id
      * @return mixed|\Psr\Container\ContainerInterface
      */


### PR DESCRIPTION
It would be great if the return type of the `di` function can be inferred through Psalm annotations. So that we can benefit from the type inference and no longer to have the return type declaration explicitly:

**Current:**
```php
//have to declare the variable type in docblock:

/** @var ClassA */
$a = \di(ClassA::class);
```

**Want:**
```php
//the type can be inferred automatically (@var is no needed):

$a = \di(ClassA::class);
```